### PR TITLE
Add GitHub Actions (CI) configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,13 @@ jobs:
             perl Makefile.PL
             make
             make test
+
+      - name: Release tests
+        env:
+          RELEASE_TESTING: 1
+        run: |
+            cpanm --installdep .
+            cpanm --notest Test::CheckManifest Test::Pod::Coverage Pod::Coverage Test::Pod
+            perl Makefile.PL
+            make
+            make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  perl-job:
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}     # https://hub.docker.com/r/perldocker/perl-tester
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.30'
+#          - '5.32'
+#          - 'latest'
+    name: Perl ${{ matrix.perl-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Regular tests
+        run: |
+            cpanm --installdep .
+            perl Makefile.PL
+            make
+            make test


### PR DESCRIPTION
The regular tests pass, but the release tests fail.
If you would like to skip them for now, you can comment out that section in the config file.